### PR TITLE
Updated docs to comply with CDS-M framework

### DIFF
--- a/hr-dataspec/config.js
+++ b/hr-dataspec/config.js
@@ -3,7 +3,7 @@ var respecConfig = { // => https://github.com/stichting-crow/respec/wiki
     specStatus: "",
     pubDomain: "deelfietsdashboard",
     shortName: "hr-dataspec",
-    publishDate: "2021-01-01",
+    publishDate: "2022-03-15",
     editors: [
         {
             name: "Sven Boor",
@@ -12,6 +12,10 @@ var respecConfig = { // => https://github.com/stichting-crow/respec/wiki
         {
             name: "Redmer Kronemeijer",
             company: "CROW",
+        },
+        {
+            name: "Bart Roorda",
+            company: "Tuxion",
         }
     ],
     github: "https://github.com/Stichting-CROW/deelfietsdashboard",

--- a/hr-dataspec/docs/abstract.md
+++ b/hr-dataspec/docs/abstract.md
@@ -4,7 +4,7 @@ The Dashboard Deelmobiliteit is used by municipalities to monitor shared mobilit
 
 The Dashboard Deelmobiliteit applies the guidelines the [CDS-M][cdsm] framework.
 
-New operators should offer the `/vehicles` and `/trips` [=MDS=] end points of the MDS [Provider API][mds-provider-api]. For compatibility purposes we currently support [=GBFS=] and [=TOMP=] as well, but these will be phases out in the future.
+New operators should offer the `/vehicles` and `/trips` [=MDS=] end points of the MDS [Provider API][mds-provider-api]. For compatibility purposes we currently support [=GBFS=] and [=TOMP=] as well, but these will be phased out in the future.
 
 <div lang='nl'>
 

--- a/hr-dataspec/docs/abstract.md
+++ b/hr-dataspec/docs/abstract.md
@@ -1,9 +1,17 @@
-This document specifies what data is used by the [CROW-Fietsberaad Dashboard deelmobiliteit][db] (_shared mobility dashboard_), following the [=MDS=], [=GBFS=] or [=TOMP=] specifications.
+This document specifies what data is used by the [CROW-Fietsberaad Dashboard Deelmobiliteit][db] (_shared mobility dashboard_).
+
+The Dashboard Deelmobiliteit is used by municipalities to monitor shared mobility within their area. It shows how long vehicles are parked in public space, how shared mobility is used and where shared mobility is available. Providers can benefit from the Dashboard Deelmobiliteit as they get less data requests from the different individual municipalitites. Also providers can use the Dashboard Deelmobiliteit for their own analyses. If all parties agree, data can be shared for mobility research and scientific research.
+
+The Dashboard Deelmobiliteit applies the guidelines the [CDS-M][cdsm] framework.
+
+New operators should offer the `/vehicles` and `/trips` [=MDS=] end points of the MDS [Provider API][mds-provider-api]. For compatibility purposes we currently support [=GBFS=] and [=TOMP=] as well, but these will be phases out in the future.
 
 <div lang='nl'>
 
-Dit document beschrijft in het Engels van het [CROW-Fietsberaad Dashboard deelmobiliteit][db] hoe gegevens van deelmobiliteit aangeleverd moeten worden.
+Dit document beschrijft in het Engels van het [CROW-Fietsberaad Dashboard Deelmobiliteit][db] hoe gegevens van deelmobiliteit aangeleverd moeten worden.
 
 </div>
 
 [db]: https://dashboarddeelmobiliteit.nl/
+[cdsm]: https://www.amsterdam.nl/innovatie/mobiliteit/city-data-standard-mobility/
+[mds-provider-api]: https://github.com/openmobilityfoundation/mobility-data-specification/blob/main/provider/README.md#mobility-data-specification-provider

--- a/hr-dataspec/docs/inleiding.md
+++ b/hr-dataspec/docs/inleiding.md
@@ -1,13 +1,7 @@
 ## Introduction
 
-The CROW-Fietsberaad Dashboard deelmobiliteit uses simple data formats to collect information on shared mobility to present to regulatory agencies, usually municipalities.
-This data is provided by operators.
-It works by requesting the location of every vehicle currently present in the public space (*openbare ruimte*).
-Vehicles removed from the public space and vehicles in use should be removed from such responses.
+The CROW-Fietsberaad Dashboard Deelmobiliteit uses MDS to collect information on shared mobility to present to regulatory agencies, usually municipalities. This data is provided by operators.
 
-There are several data formats available for this exchange.
-CROW deelfietsdashboard prefers MDS’s [`/vehicles`](https://github.com/openmobilityfoundation/mobility-data-specification/blob/main/provider/README.md#vehicles) endpoint, as MDS was designed for regulatory use.
-GBFS and TOMP-API are also possible data exchange formats but have been designed for traveler information.
-Therefore, some modifications were made to the specification to deduce trips from available vehicles.
+CROW Dashboard Deelmobiliteit requires MDS, a data standard designed for regulatory use. With this we are following the selected CDS-M data standard.
 
-_We strongly recomend to use MDS [`/vehicles`](https://github.com/openmobilityfoundation/mobility-data-specification/blob/main/provider/README.md#vehicles) endpoint when you rely on a external supplier for your software systems. Because it's the only standard we support without small modifications on the original standards._
+In the past GBFS and TOMP were supported as well for compatibility reasons. These data formats will be phased out, as these are designed for traveler information and not regulatory purposes.

--- a/hr-dataspec/docs/specs.md
+++ b/hr-dataspec/docs/specs.md
@@ -44,7 +44,7 @@ The providers shall provide [authorization][mds-auth] for API endpoints via a to
 
 In the past CROW Dashboard supported the GBFS and TOMP APIs. As these standards are designed for traveler information and not for regulatory purposes, since 2022 MDS is required.
 
-MDS is a grown up standard up that is widely applied in Europe and the USA and therefor a future proof data exchange format to support municipalities with regulating and monitoring shared mobility operations.
+MDS is a mature standard up that is widely applied across Europe and North America, and therefore a future proof data exchange standard to support municipalities with regulating and monitoring shared mobility operations.
 
 ### GBFS (customized) (deprecated)
 

--- a/hr-dataspec/docs/specs.md
+++ b/hr-dataspec/docs/specs.md
@@ -1,49 +1,55 @@
 ## Data specifications
 
-The [=operator=] MUST provide data conforming to one of the below described specifications.
-
-Customized feeds MAY be implemented as an alternative to [=MDS=].
-
-| Standard                 | Note                                                                      |
-| ------------------------ | ------------------------------------------------------------------------- |
-| [MDS](#mds)              | Preferred.                                                                |
-| [GBFS](#gbfs-customized) | Requires a customized feed for CROW-Fietsberaad Dashboard deelmobiliteit. |
-| [TOMP](#tomp-customized) | Requires a customized feed for CROW-Fietsberaad Dashboard deelmobiliteit. |
-
-{.data}
+The [=operator=] MUST provide data conforming to a subset of MDS.
 
 ### General
 
 Parked vehicles that are present in the public space (i.e., PROW) MUST be present in the supplied data.
+
 That includes reserved and disabled vehicles or vehicles with empty batteries, etc. that take up place in the public space.
+
 Inversely, vehicles removed from the public space MUST NOT be returned.
 
 Data provided in a feed or endpoint MUST be updated at least every 30 seconds.
 The update frequency MAY be higher.
 
-### MDS
+### MDS /vehicles
 
-Based on [endpoint specification][1]: `/vehicles`.
+The provider must offer [`/vehicles`][1] endpoint, part of the MDS Provider API.
 
-Below fields MUST be supplied for the Dashboard deelmobiliteit.
-Other field MAY be filled and indeed are required by the MDS specification.
+CROW Dashboard uses this endpoint to get a current snapshot of all vehicles in public space, at any moment.
 
-| Value                 | Note            |
-| --------------------- | --------------- |
-| `current_location`    | always REQUIRED |
-| `device_id`           | always REQUIRED |
-| `last_event_location` | always REQUIRED |
-| `last_event_types`    | always REQUIRED |
-| `last_vehicle_state`  | always REQUIRED |
-| `propulsion_types`    | always REQUIRED |
-| `vehicle_type`        | always REQUIRED |
+NOTE: In the [=Vehicle types=] we help you set the right vehicle type for every vehicle in this feed.
 
 [1]: https://github.com/openmobilityfoundation/mobility-data-specification/blob/main/provider/README.md#vehicles
 
-### GBFS (customized)
+### MDS /trips
+
+The provider must offer [`/trips`][mds-trips] endpoint, part of the MDS Provider API.
+
+CROW Dashboard uses this endpoint to get the exact historical rentals.
+
+NOTE: For the [`route`][mds-trips-routes] property only the start and end of a rental are required. 
+
+[mds-trips]: https://github.com/openmobilityfoundation/mobility-data-specification/blob/main/provider/README.md#trips
+[mds-trips-routes]: https://github.com/openmobilityfoundation/mobility-data-specification/blob/main/provider/README.md#routes
+
+### MDS authorization
+
+The providers shall provide [authorization][mds-auth] for API endpoints via a token based auth system.
+
+[mds-auth]: https://github.com/openmobilityfoundation/mobility-data-specification/blob/main/provider/auth.md#authorization
+
+## Deprecated data specifications
+
+In the past CROW Dashboard supported the GBFS and TOMP APIs. As these standards are designed for traveler information and not for regulatory purposes, since 2022 MDS is required.
+
+MDS is a grown up standard up that is widely applied in Europe and the USA and therefor a future proof data exchange format to support municipalities with regulating and monitoring shared mobility operations.
+
+### GBFS (customized) (deprecated)
 
 <div class="note">
-GBFS does not provide enough information for the Dashboard deelmobiliteit. 
+GBFS does not provide enough information for the Dashboard Deelmobiliteit. 
 Therefore, the specification has been extended to provide the required information.
 </div>
 
@@ -64,10 +70,10 @@ It MAY be rotated after being removed from public space.
 [2]: https://github.com/NABSA/gbfs/blob/master/gbfs.md#free_bike_statusjson
 [vehicle_types]: https://github.com/NABSA/gbfs/blob/master/gbfs.md#vehicle_typesjson-added-in-v21
 
-### TOMP (customized)
+### TOMP (customized) (deprecated)
 
 <div class="note">
-TOMP by itself does not provide enough information for Dashboard deelmobiliteit. 
+TOMP by itself does not provide enough information for Dashboard Deelmobiliteit. 
 Therefore, the specification has been extended to provide the required information.
 </div>
 

--- a/hr-dataspec/docs/specs.md
+++ b/hr-dataspec/docs/specs.md
@@ -27,7 +27,7 @@ NOTE: In the [=Vehicle types=] we help you set the right vehicle type for every 
 
 The provider must offer [`/trips`][mds-trips] endpoint, part of the MDS Provider API.
 
-CROW Dashboard uses this endpoint to get the exact historical rentals.
+CROW Dashboard Deelmobiliteit uses this endpoint to get the exact historical rentals.
 
 NOTE: For the [`route`][mds-trips-routes] property only the start and end of a rental are required. 
 

--- a/hr-dataspec/docs/voertuigtypen.md
+++ b/hr-dataspec/docs/voertuigtypen.md
@@ -1,13 +1,12 @@
-## Vehicle Types
+## Vehicle types
 
 This section helps you in choosing the right vehicle type.
 
 First, we show the different types of vehicle types that are supported in the Dashboard Deelmobiliteit.
 
-After that, we show exactly how to implement this in your GBFS, MDS or TOMP data feed.
+After that, we show exactly how to implement this in your MDS (and GBFS, deprecated) data feed.
 
 ### Supported vehicle types
-
 
 | English                     | Dutch                       |
 | --------------------------- | --------------------------- |
@@ -20,39 +19,6 @@ After that, we show exactly how to implement this in your GBFS, MDS or TOMP data
 | Electric cargo bike         | Elektrisch bakfiets          |
 | Shared combustion car       | Deelauto met verbrandingsmotor |
 | Shared electric car         | Elektrisch deelauto          | 
-
-### How to offer vehicle type in GBFS?
-
-Since GBFS 2.1 you can share information on what vehicle type is offered.
-
-Please share vehicle type information in your GBFS feed:
-
-1. Offer [vehicle_types.json](https://github.com/NABSA/gbfs/blob/c3622c52f2cf08675a56a46445ecf7fbe5595f7f/gbfs.md#vehicle_typesjson-added-in-v21)
-2. In free_bike_status.json, add property [vehicle_type_id](https://github.com/NABSA/gbfs/blob/master/gbfs.md#free_bike_statusjson)
-
-We ask you to share:
-
-- `vehicle_type_id`
-- `form_factor`
-- `propulsion_type`
-- `max_permitted_speed` (optional though required if you offer a moped)
-- `wheel_count`         (optional)
-
-In the table below you'll find all the combinations possible.
-
-| vehicle type                | form_factor       | propulsion_type | max_permitted_speed
-| ---------------             | ----------------- | --------------- | ----------- 
-| Bicycle                     | bicycle           | human           | -
-| Bicycle with pedal assist   | bicycle           | electric_assist | 25
-| Moped <= 25 km/h            | moped             | electric        | 25
-| Moped                       | moped             | electric        | 45
-| Scooter                     | scooter_standing  | electric        | 25
-| Human powered cargo bike    | cargo_bicycle     | human           | -
-| Electric cargo bike         | cargo_bicycle     | electric_assist | 25
-| Shared combustion car       | car               | combustion      | -
-| Shared electric car         | car               | electric        | -
-
-If you have questions on implementing a specific vehicle type, send an email to [info@deelfietsdashboard.nl](mailto:info@deelfietsdashboard.nl).
 
 ### How to offer vehicle type in MDS?
 
@@ -86,3 +52,35 @@ In the table below you'll find all the combinations possible.
 
 If you have questions on implementing a specific vehicle type, send an email to [info@deelfietsdashboard.nl](mailto:info@deelfietsdashboard.nl).
 
+### How to offer vehicle type in GBFS? (deprecated)
+
+Since GBFS 2.1 you can share information on what vehicle type is offered.
+
+Please share vehicle type information in your GBFS feed:
+
+1. Offer [vehicle_types.json](https://github.com/NABSA/gbfs/blob/c3622c52f2cf08675a56a46445ecf7fbe5595f7f/gbfs.md#vehicle_typesjson-added-in-v21)
+2. In free_bike_status.json, add property [vehicle_type_id](https://github.com/NABSA/gbfs/blob/master/gbfs.md#free_bike_statusjson)
+
+We ask you to share:
+
+- `vehicle_type_id`
+- `form_factor`
+- `propulsion_type`
+- `max_permitted_speed` (optional though required if you offer a moped)
+- `wheel_count`         (optional)
+
+In the table below you'll find all the combinations possible.
+
+| vehicle type                | form_factor       | propulsion_type | max_permitted_speed
+| ---------------             | ----------------- | --------------- | ----------- 
+| Bicycle                     | bicycle           | human           | -
+| Bicycle with pedal assist   | bicycle           | electric_assist | 25
+| Moped <= 25 km/h            | moped             | electric        | 25
+| Moped                       | moped             | electric        | 45
+| Scooter                     | scooter_standing  | electric        | 25
+| Human powered cargo bike    | cargo_bicycle     | human           | -
+| Electric cargo bike         | cargo_bicycle     | electric_assist | 25
+| Shared combustion car       | car               | combustion      | -
+| Shared electric car         | car               | electric        | -
+
+If you have questions on implementing a specific vehicle type, send an email to [info@deelfietsdashboard.nl](mailto:info@deelfietsdashboard.nl).

--- a/hr-dataspec/index.html
+++ b/hr-dataspec/index.html
@@ -13,13 +13,6 @@
 
 <body>
   <section id="abstract" data-format="markdown" data-include="docs/abstract.md"></section>
-  <section class="introductory" id="sotd">
-    <h2>State of this document</h2>
-    <p>
-      This document is a guide to provide data on shared mobility.
-      The present specifications may change at any time and without notice.
-    </p>
-  </section>
   <section class="introductory" id="conformance"></section> 
   <section data-format="markdown" class="informative" data-include="docs/inleiding.md"></section>
   <section data-format="markdown"                     data-include="docs/specs.md"></section>


### PR DESCRIPTION
We updated the docs, with the following changes:

- MDS is the standard we require - GBFS and TOMP are deprecated
- For MDS we documented the `/vehicles` and `/trips` endpoints
- For MDS we added info on authorization
- We referenced CDS-M